### PR TITLE
Allow to load config from an object rather than from filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ var configury = require('configury')
 
 ```
 
+Using configuration already loaded on memory (you can't use `.write` if you load config this way):
+
+```js
+var configury = require('configury')
+  , properties = require('./properties.json')
+  , config = configury(properties)
+
+```
+
 ### config.raw()
 
 ```js

--- a/configury.js
+++ b/configury.js
@@ -11,7 +11,7 @@ function Configury(configPath, defaultSection) {
 
   if (!defaultSection) defaultSection = 'global'
 
-  if (configPath && fs.existsSync(configPath)) {
+  if (configPath && typeof configPath === 'string' && fs.existsSync(configPath)) {
     try {
       raw = JSON.parse(fs.readFileSync(configPath))
     } catch (e) {
@@ -21,7 +21,9 @@ function Configury(configPath, defaultSection) {
         throw e
       }
     }
-
+  }
+  else if (configPath && typeof configPath === 'object') {
+    raw = configPath
   }
 
   function substitute(config, value) {

--- a/test/configury.test.js
+++ b/test/configury.test.js
@@ -16,6 +16,19 @@ describe('configury.js', function () {
     config.should.eql({})
   })
 
+  it('should allow to use object rather than file path', function () {
+    var mockConfig =
+      { global:
+        { foo: 'bar' }
+      }
+
+    var configury = createConfigury(mockConfig)
+      , config = configury()
+
+    config.should.be.type('object')
+    config.should.have.property('foo', 'bar')
+  })
+
   describe('#set', function () {
     it('should add a global property', function () {
       var configury = createConfigury()


### PR DESCRIPTION
This can be useful if you want to load dynamic config, for instance using environment variable overrides.
This should not break backward compatibility.

Added a test and updated README for the new use case, hope everything looks good!

(thanks @microadam for his help on this one)